### PR TITLE
(GH-2629) Add top-level metaparameter keys to YAML plan steps

### DIFF
--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -77,7 +77,7 @@ Each plan name segment must begin with a lowercase letter and:
 
 ## Plan structure
 
-YAML plans contain a list of steps and can include additional optional keys.
+YAML plans contain a list of steps and can include optional top-level keys.
 The following top-level keys are available:
 
 | Key | Type | Description | Required |
@@ -93,14 +93,14 @@ The following top-level keys are available:
 The `steps` key is an array of step objects, each of which corresponds to a
 specific action to take.
 
-When the plan runs, each step is executed in order. By default, if a step fails
-the plan halts execution and raises an error containing the result of the step
-that failed.
+When the plan runs, each step is executed in order. If a step fails the plan
+halts execution and raises an error containing the result of the step that
+failed.
 
 ### Message step
 
-Use a `message` step to print a message. This will print a message to standard
-out (stdout) when using the `human` output format, and print to standard error
+Use a `message` step to print a message. The step prints a message to standard
+out (stdout) when using the `human` output format, and prints to standard error
 (stderr) when using the `json` output format. 
 
 Message steps support the following keys:
@@ -134,7 +134,7 @@ Command steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `command` | `String` | The command to run. | ✓ |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `env_vars` | `Hash` | A map of environment variables to set on the target when running the command. | |
@@ -162,7 +162,7 @@ Task steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `name` | `String` | The name of the variable to save the step result to. | |
 | `noop` | `Boolean` | Whether to run in no-operation mode, if available. | |
@@ -199,7 +199,7 @@ Script steps support the following keys:
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
 | `arguments` | `Array` | An array of command-line arguments to pass to the script. | |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `env_vars` | `Hash` | A map of environment variables to set on the target when running the script. | |
 | `name` | `String` | The name of the variable to save the step result to. | |
@@ -236,7 +236,7 @@ File download steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `destination` | `String` | The destination directory to download the file to. | ✓ |
 | `download` | `String` | The location of the remote file to download. | ✓ |
@@ -283,7 +283,7 @@ File upload steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `destination` | `String` | The remote location to upload the file to. | ✓ |
 | `name` | `String` | The name of the variable to save the step result to. | |
@@ -316,7 +316,7 @@ Plan steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
 | `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `name` | `String` | The name of the variable to save the step result to. | |
 | `parameters` | `Hash` | A map of parameters to pass to the plan. | |
@@ -353,8 +353,12 @@ Resources steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan continues execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
 | `name` | `String` | The name of the variable to save the step result to. | |
+| `noop` | `Boolean` | Whether to run in no-operation mode. If set to true, applies the resources in Puppet no-operation mode, returning a report of the changes it would make while taking no action. | |
 | `resources` | `Array` | An array of resources to apply. | ✓ |
+| `run_as` | `String` | The user to run as when connecting to targets. Only applies to targets using a transport that supports `run-as` configuration. | |
 | `targets` | `Array`, `String` | A target or list of targets to run the script on. | ✓ |
 
 Each resource is a YAML map with a type and title, and optionally a `parameters`
@@ -381,6 +385,34 @@ steps:
       - web2.example.com
       - web3.example.com
     description: "Set up nginx on the webservers"
+```
+
+### Eval step
+
+The `eval` step evaluates an expression and saves the result in a variable. This
+is useful to compute a variable to use multiple times later.
+
+Eval steps support the following keys:
+
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `eval` | `Array`, `Boolean`, `Hash`, `Number`, `String` | The expression to evaluate. | ✓ |
+| `name` | `String` | The name of the variable to save the step result to. | |
+
+For example:
+
+```yaml
+parameters:
+  count:
+    type: Integer
+
+steps:
+  - name: double_count
+    eval: $count * 2
+  - task: echo
+    targets: web1.example.com
+    parameters:
+      message: "The count is ${count}, and twice the count is ${double_count}"
 ```
 
 ## Parameters
@@ -611,25 +643,6 @@ steps:
   - task: echo
     parameters:
       message: $hostnames.map |$hostname_result| { $hostname_result['stdout'] }.join(',')
-```
-
-### `eval` step
-
-The `eval` step evaluates an expression and saves the result in a variable. This
-is useful to compute a variable to use multiple times later.
-
-```yaml
-parameters:
-  count:
-    type: Integer
-
-steps:
-  - name: double_count
-    eval: $count * 2
-  - task: echo
-    targets: web1.example.com
-    parameters:
-      message: "The count is ${count}, and twice the count is ${double_count}"
 ```
 
 ## Returning results

--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -77,40 +77,37 @@ Each plan name segment must begin with a lowercase letter and:
 
 ## Plan structure
 
-YAML plans contain a list of steps with optional parameters and results.
+YAML plans contain a list of steps and can include additional optional keys.
+The following top-level keys are available:
 
-YAML maps accept these keys:
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `description` | `String` | The plan description. Appears in `bolt plan show <PLAN NAME>` and `Get-BoltPlan <PLAN NAME>` output. | |
+| `parameters` | `Hash` | A hash of plan parameters. Each key is the name of the parameter and the value is the parameter definition. | |
+| `private` | `Boolean` | Whether the plan should appear in `bolt plan show` and `Get-BoltPlan` output. | |
+| `return` | `Array`, `Boolean`, `Hash`, `Number`, `String` | The value to return from the plan. Must evaluate to a valid [PlanResult](bolt_types_reference.md#planresult). | |
+| `steps` | `Array` | The list of steps to run. | ✓ |
 
--   `steps`: The list of steps to perform
--   `parameters`: (Optional) The parameters accepted by the plan
--   `return`: (Optional) The value to return from the plan
-
-### Steps key
+## Steps
 
 The `steps` key is an array of step objects, each of which corresponds to a
 specific action to take.
 
-When the plan runs, each step is executed in order. If a step fails, the plan
-halts execution and raises an error containing the result of the step that
-failed.
+When the plan runs, each step is executed in order. By default, if a step fails
+the plan halts execution and raises an error containing the result of the step
+that failed.
 
-Steps use these fields:
-
--   `name`: (Optional) A unique name that can be used to refer to the result of
-    the step later.
--   `description`: (Optional) An explanation of what the step is doing.
-
-Other available keys depend on the type of step.
-
-#### Message step
+### Message step
 
 Use a `message` step to print a message. This will print a message to standard
 out (stdout) when using the `human` output format, and print to standard error
 (stderr) when using the `json` output format. 
 
-Message steps use a single field:
+Message steps support the following keys:
 
-- `message`: The message to print
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `message` | `String` | The message to print. | ✓ |
 
 For example:
 
@@ -127,17 +124,23 @@ prints the object as a string.
 For information on printing a step result with `message`, see [Debugging
 plans](#debugging-plans).
 
-#### Command step
+### Command step
 
 Use a `command` step to run a single command on a list of targets and save the
-results, containing stdout, stderr, and exit code.
+results, containing stdout, stderr, and exit code. The step fails if the exit
+code of any command is non-zero.
 
-The step fails if the exit code of any command is non-zero.
+Command steps support the following keys:
 
-Command steps use these fields:
-
--   `command`: The command to run
--   `targets`: A target or list of targets to run the command on
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `command` | `String` | The command to run. | ✓ |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `env_vars` | `Hash` | A map of environment variables to set on the target when running the command. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when running the command on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to run the command on. | ✓ |
 
 For example:
 
@@ -151,15 +154,22 @@ steps:
     description: "Get the webserver hostnames"
 ```
 
-#### Task step
+### Task step
 
 Use a `task` step to run a Bolt task on a list of targets and save the results.
 
-Task steps use these fields:
+Task steps support the following keys:
 
--   `task`: The task to run
--   `targets`: A target or list of targets to run the task on
--   `parameters`: (Optional) A map of parameter values to pass to the task
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `noop` | `Boolean` | Whether to run in no-operation mode, if available. | |
+| `parameters` | `Hash` | A map of parameters to pass to the task. | |
+| `run_as` | `String` | The user to run as when running the task on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to run the task on. | ✓ |
+| `task` | `String` | The task to run. | ✓ |
 
 For example:
 
@@ -176,7 +186,7 @@ steps:
       name: openssl
 ```
 
-#### Script step
+### Script step
 
 Use a `script` step to run a script on a list of targets and save the results.
 
@@ -184,12 +194,18 @@ The script must be in the `files/` directory of a module. The name of the script
 must be specified as `<modulename>/path/to/script`, omitting the `files`
 directory from the path.
 
-Script steps use these fields:
+Script steps support the following keys:
 
--   `script`: The script to run
--   `targets`: A target or list of targets to run the script on
--   `arguments`: (Optional) An array of command-line arguments to pass to the
-    script
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `arguments` | `Array` | An array of command-line arguments to pass to the script. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `env_vars` | `Hash` | A map of environment variables to set on the target when running the script. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when running the script on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `script` | `String` | The script to run. | ✓ |
+| `targets` | `Array`, `String` | A target or list of targets to run the script on. | ✓ |
 
 For example:
 
@@ -206,7 +222,7 @@ steps:
       - 60
 ```
 
-#### File download step
+### File download step
 
 Use a file download step to download a file or directory from a list of targets
 to a destination directory on the local host.
@@ -216,11 +232,17 @@ subdirectory matching the target's URL-encoded safe name. If the destination
 directory is a relative path, it will expand relative to the project's
 downloads directory, `<PROJECT DIRECTORY>/downloads`.
 
-File download steps use these fields:
+File download steps support the following keys:
 
-- `download`: The location of the remote file to download
-- `destination`: The destination directory to download the file to
-- `targets`: A target or list of targets to download the file from
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `destination` | `String` | The destination directory to download the file to. | ✓ |
+| `download` | `String` | The location of the remote file to download. | ✓ |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when downloading the file from the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to download the file from. | ✓ |
 
 For example:
 
@@ -248,7 +270,7 @@ target's safe name is URL encoded to ensure it's a valid directory name.
 > 🔩 **Tip:** To avoid URL encoding the target's safe name, give the target a
 > simple, human-readable name in your inventory file.
 
-#### File upload step
+### File upload step
 
 Use a file upload step to upload a file to a specific location on a list of
 targets.
@@ -257,7 +279,17 @@ The file to upload must be in the `files/` directory of a Puppet module. The
 source for the file must be specified as `<modulename>/path/to/file`, omitting
 the `files` directory from the path.
 
-File upload steps use these fields:
+File upload steps support the following keys:
+
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `destination` | `String` | The remote location to upload the file to. | ✓ |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when uploading the file to the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to upload the file to. | ✓ |
+| `upload` | `String` | The location of the local file to upload. | ✓ |
 
 -   `upload`: The location of the local file to be uploaded
 -   `destination`: The remote location to upload the file to
@@ -276,14 +308,21 @@ steps:
     description: "Upload motd to the webservers"
 ```
 
-#### Plan step
+### Plan step
 
 Use a `plan` step to run another plan and save its result.
 
-Plan steps use these fields:
+Plan steps support the following keys:
 
--   `plan`: The name of the plan to run
--   `parameters`: (Optional) A map of parameter values to pass to the plan
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `parameters` | `Hash` | A map of parameters to pass to the plan. | |
+| `plan` | `String` | The plan to run. | ✓ |
+| `run_as` | `String` | The user to run as when connecting to targets. This is set for all steps or functions in the plan that connect to targets. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets. Passed to the plan under the `targets` parameter. | |
 
 For example:
 
@@ -298,7 +337,7 @@ steps:
         - web3.example.com
 ```
 
-#### Resources step
+### Resources step
 
 Use a `resources` step to apply a list of Puppet resources. A resource defines
 the desired state for part of a target. Bolt ensures each resource is in its
@@ -310,10 +349,13 @@ the targets specified with the `targets` field. For more information about
 `apply_prep` see the [Applying manifest blocks](applying_manifest_blocks.md#)
 section.
 
-Resources steps use these fields:
+Resources steps support the following keys:
 
--   `resources`: An array of resources to apply
--   `targets`: A target or list of targets to apply the resources on
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `resources` | `Array` | An array of resources to apply. | ✓ |
+| `targets` | `Array`, `String` | A target or list of targets to run the script on. | ✓ |
 
 Each resource is a YAML map with a type and title, and optionally a `parameters`
 key. The resource type and title can either be specified separately with the
@@ -341,7 +383,7 @@ steps:
     description: "Set up nginx on the webservers"
 ```
 
-### Parameters key
+## Parameters
 
 Plans accept parameters with the `parameters` key. The value of `parameters` is
 a map, where each key is the name of a parameter and the value is a map
@@ -375,7 +417,7 @@ parameters:
     description: "The new application version to deploy"
 ```
 
-### Private key
+## Private plans
 
 As a plan author, you may not want users to run your plan directly or know it exists. This is useful
 for plans that are used by other plans 'under the hood', but aren't designed to be run by a human.
@@ -407,7 +449,7 @@ If you manually edit a plan that is located outside of the `<PROJECT DIRECTORY>/
 still appears in the output of `bolt plan show` and `Get-BoltPlan`, clear the metadata cache by
 running with the `--clear-cache` flag.
 
-### How strings are evaluated
+## How strings are evaluated
 
 The behavior of strings is defined by how they're written in the plan.
 

--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -73,8 +73,7 @@ module Bolt
       def duplicate_check(used_names, name, step_number)
         if used_names.include?(name)
           error_message = "Duplicate step name or parameter detected: #{name.inspect}"
-          err = Step.step_error(error_message, name, step_number)
-          raise Bolt::Error.new(err, "bolt/invalid-plan")
+          raise Step::StepError.new(error_message, name, step_number)
         end
       end
 

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -12,153 +12,15 @@ module Bolt
           @evaluator = Puppet::Pops::Parser::EvaluatingParser.new
         end
 
-        def dispatch_step(scope, step)
-          step_body = evaluate_code_blocks(scope, step.body)
-
-          # Dispatch based on the step class name
-          step_type = step.class.name.split('::').last.downcase
-          method = "#{step_type}_step"
-
-          send(method, scope, step_body)
-        end
-
-        def task_step(scope, step)
-          task = step['task']
-          targets = step['targets']
-          description = step['description']
-          params = step['parameters'] || {}
-
-          args = if description
-                   [task, targets, description, params]
-                 else
-                   [task, targets, params]
-                 end
-
-          scope.call_function('run_task', args)
-        end
-
-        def plan_step(scope, step)
-          plan = step['plan']
-          parameters = step['parameters'] || {}
-
-          args = [plan, parameters]
-
-          scope.call_function('run_plan', args)
-        end
-
-        def script_step(scope, step)
-          script = step['script']
-          targets = step['targets']
-          description = step['description']
-          arguments = step['arguments'] || []
-
-          options = { 'arguments' => arguments }
-          args = if description
-                   [script, targets, description, options]
-                 else
-                   [script, targets, options]
-                 end
-
-          scope.call_function('run_script', args)
-        end
-
-        def command_step(scope, step)
-          command = step['command']
-          targets = step['targets']
-          description = step['description']
-
-          args = [command, targets]
-          args << description if description
-          scope.call_function('run_command', args)
-        end
-
-        def upload_step(scope, step)
-          source = step['upload']
-          destination = step['destination']
-          targets = step['targets']
-          description = step['description']
-
-          args = [source, destination, targets]
-          args << description if description
-          scope.call_function('upload_file', args)
-        end
-
-        def download_step(scope, step)
-          source = step['download']
-          destination = step['destination']
-          targets = step['targets']
-          description = step['description']
-
-          args = [source, destination, targets]
-          args << description if description
-          scope.call_function('download_file', args)
-        end
-
-        def eval_step(_scope, step)
-          step['eval']
-        end
-
-        def resources_step(scope, step)
-          targets = step['targets']
-
-          # TODO: Only call apply_prep when needed
-          scope.call_function('apply_prep', targets)
-          manifest = generate_manifest(step['resources'])
-
-          apply_manifest(scope, targets, manifest)
-        end
-
-        def message_step(scope, step)
-          scope.call_function('out::message', [step['message']])
-        end
-
-        def generate_manifest(resources)
-          # inspect returns the Ruby representation of the resource hashes,
-          # which happens to be the same as the Puppet representation
-          puppet_resources = resources.inspect
-
-          # Because the :tasks setting globally controls which mode the parser
-          # is in, we need to make this snippet of non-tasks manifest code
-          # parseable in tasks mode. The way to do that is by putting it in an
-          # apply statement and taking the body.
-          <<~MANIFEST
-          apply('placeholder') {
-            $resources = #{puppet_resources}
-            $resources.each |$res| {
-              Resource[$res['type']] { $res['title']:
-                * => $res['parameters'],
-              }
-            }
-
-            # Add relationships if there is more than one resource
-            if $resources.length > 1 {
-              ($resources.length - 1).each |$index| {
-                $lhs = $resources[$index]
-                $rhs = $resources[$index+1]
-                $lhs_resource = Resource[$lhs['type'] , $lhs['title']]
-                $rhs_resource = Resource[$rhs['type'] , $rhs['title']]
-                $lhs_resource -> $rhs_resource
-              }
-            }
-          }
-          MANIFEST
-        end
-
-        def apply_manifest(scope, targets, manifest)
-          ast = @evaluator.parse_string(manifest)
-          apply_block = ast.body.body
-          applicator = Puppet.lookup(:apply_executor)
-          applicator.apply([targets], apply_block, scope)
-        end
-
         # This is the method that Puppet calls to evaluate the plan. The name
         # makes more sense for .pp plans.
+        #
         def evaluate_block_with_bindings(closure_scope, args_hash, plan)
           plan_result = closure_scope.with_local_scope(args_hash) do |scope|
             plan.steps.each do |step|
-              step_result = dispatch_step(scope, step)
+              step_result = step.evaluate(scope, self)
 
-              scope.setvar(step.name, step_result) if step.name
+              scope.setvar(step.body['name'], step_result) if step.body['name']
             end
 
             evaluate_code_blocks(scope, plan.return)
@@ -168,6 +30,7 @@ module Bolt
         end
 
         # Recursively evaluate any EvaluableString instances in the object.
+        #
         def evaluate_code_blocks(scope, value)
           # XXX We should establish a local scope here probably
           case value
@@ -192,6 +55,7 @@ module Bolt
         # Occasionally the Closure will ask us to evaluate what it assumes are
         # AST objects. Because we've sidestepped the AST, they aren't, so just
         # return the values as already evaluated.
+        #
         def evaluate(value, _scope)
           value
         end

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -86,7 +86,7 @@ module Bolt
         # Formats a list of args from the provided body
         #
         private def format_args(_body)
-          raise NotImplementedError, "Step class #{self.class} does not implement #args"
+          raise NotImplementedError, "Step class #{self.class} does not implement #format_args"
         end
 
         # Returns the step's corresponding Puppet language function call

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -6,11 +6,7 @@ module Bolt
   class PAL
     class YamlPlan
       class Step
-        attr_reader :name, :type, :body, :targets
-
-        def self.allowed_keys
-          Set['name', 'description', 'targets']
-        end
+        attr_reader :body
 
         STEP_KEYS = %w[
           command
@@ -24,15 +20,42 @@ module Bolt
           upload
         ].freeze
 
+        class StepError < Bolt::Error
+          def initialize(message, name, step_number)
+            identifier = name ? name.inspect : "number #{step_number}"
+            error      = "Parse error in step #{identifier}: \n #{message}"
+
+            super(error, 'bolt/invalid-plan')
+          end
+        end
+
+        # Keys that are allowed for the step
+        #
+        def self.allowed_keys
+          required_keys + option_keys + Set['name', 'description', 'targets']
+        end
+
+        # Keys that translate to metaparameters for the plan step's function call
+        #
+        def self.option_keys
+          Set.new
+        end
+
+        # Keys that are required for the step
+        #
+        def self.required_keys
+          Set.new
+        end
+
         def self.create(step_body, step_number)
           type_keys = (STEP_KEYS & step_body.keys)
           case type_keys.length
           when 0
-            raise step_error("No valid action detected", step_body['name'], step_number)
+            raise StepError.new("No valid action detected", step_body['name'], step_number)
           when 1
             type = type_keys.first
           else
-            raise step_error("Multiple action keys detected: #{type_keys.inspect}", step_body['name'], step_number)
+            raise StepError.new("Multiple action keys detected: #{type_keys.inspect}", step_body['name'], step_number)
           end
 
           step_class = const_get("Bolt::PAL::YamlPlan::Step::#{type.capitalize}")
@@ -40,15 +63,49 @@ module Bolt
           step_class.new(step_body)
         end
 
-        def initialize(step_body)
-          @name = step_body['name']
-          @description = step_body['description']
-          @targets = step_body['targets']
-          @body = step_body
+        def initialize(body)
+          @body = body
         end
 
+        # Transpiles the step into the plan language
+        #
         def transpile
-          raise NotImplementedError, "Step #{@name} does not supported conversion to Puppet plan language"
+          code = String.new("  ")
+          code << "$#{body['name']} = " if body['name']
+          code << function_call(function, format_args(body))
+          code << "\n"
+        end
+
+        # Evaluates the step
+        #
+        def evaluate(scope, evaluator)
+          evaluated = evaluator.evaluate_code_blocks(scope, body)
+          scope.call_function(function, format_args(evaluated))
+        end
+
+        # Formats a list of args from the provided body
+        #
+        private def format_args(_body)
+          raise NotImplementedError, "Step class #{self.class} does not implement #args"
+        end
+
+        # Returns the step's corresponding Puppet language function call
+        #
+        private def function_call(function, args)
+          code_args = args.map { |arg| Bolt::Util.to_code(arg) }
+          "#{function}(#{code_args.join(', ')})"
+        end
+
+        # The function that corresponds to the step
+        #
+        private def function
+          raise NotImplementedError, "Step class #{self.class} does not implement #function"
+        end
+
+        # Returns a hash of options formatted for function calls
+        #
+        private def format_options(body)
+          body.slice(*self.class.option_keys).transform_keys { |key| "_#{key}" }
         end
 
         def self.validate(body, step_number)
@@ -57,19 +114,35 @@ module Bolt
           begin
             body.each { |k, v| validate_puppet_code(k, v) }
           rescue Bolt::Error => e
-            raise step_error(e.msg, body['name'], step_number)
+            raise StepError.new(e.msg, body['name'], step_number)
+          end
+
+          if body.key?('parameters')
+            unless body['parameters'].is_a?(Hash)
+              raise StepError.new("Parameters key must be a hash", body['name'], step_number)
+            end
+
+            metaparams = option_keys.map { |key| "_#{key}" }
+
+            if (dups = body['parameters'].keys & metaparams).any?
+              raise StepError.new(
+                "Cannot specify metaparameters when using top-level keys with same name: #{dups.join(', ')}",
+                body['name'],
+                step_number
+              )
+            end
           end
 
           unless body.fetch('parameters', {}).is_a?(Hash)
             msg = "Parameters key must be a hash"
-            raise step_error(msg, body['name'], step_number)
+            raise StepError.new(msg, body['name'], step_number)
           end
 
           if body.key?('name')
             name = body['name']
             unless name.is_a?(String) && name.match?(Bolt::PAL::YamlPlan::VAR_NAME_PATTERN)
               error_message = "Invalid step name: #{name.inspect}"
-              raise step_error(error_message, body['name'], step_number)
+              raise StepError.new(error_message, body['name'], step_number)
             end
           end
         end
@@ -81,8 +154,7 @@ module Bolt
           illegal_keys = body.keys.to_set - allowed_keys
           if illegal_keys.any?
             error_message = "The #{step_type.inspect} step does not support: #{illegal_keys.to_a.inspect} key(s)"
-            err = step_error(error_message, body['name'], step_number)
-            raise Bolt::Error.new(err, "bolt/invalid-plan")
+            raise StepError.new(error_message, body['name'], step_number)
           end
 
           # Ensure all required keys are present
@@ -90,8 +162,7 @@ module Bolt
 
           if missing_keys.any?
             error_message = "The #{step_type.inspect} step requires: #{missing_keys.to_a.inspect} key(s)"
-            err = step_error(error_message, body['name'], step_number)
-            raise Bolt::Error.new(err, "bolt/invalid-plan")
+            raise StepError.new(error_message, body['name'], step_number)
           end
         end
 
@@ -123,12 +194,6 @@ module Bolt
           raise Bolt::Error.new("Error parsing #{step_key.inspect}: #{e.basic_message}", "bolt/invalid-plan")
         end
 
-        def self.step_error(message, name, step_number)
-          identifier = name ? name.inspect : "number #{step_number}"
-          error = "Parse error in step #{identifier}: \n #{message}"
-          Bolt::Error.new(error, 'bolt/invalid-plan')
-        end
-
         # Parses the an evaluable string, optionally quote it before parsing
         def self.parse_code_string(code, quote = false)
           if quote
@@ -137,11 +202,6 @@ module Bolt
           else
             Puppet::Pops::Parser::EvaluatingParser.new.parse_string(code)
           end
-        end
-
-        def function_call(function, args)
-          code_args = args.map { |arg| Bolt::Util.to_code(arg) }
-          "#{function}(#{code_args.join(', ')})"
         end
       end
     end

--- a/lib/bolt/pal/yaml_plan/step/command.rb
+++ b/lib/bolt/pal/yaml_plan/step/command.rb
@@ -5,30 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Command < Step
-          def self.allowed_keys
-            super + Set['command']
+          def self.option_keys
+            Set['catch_errors', 'env_vars', 'run_as']
           end
 
           def self.required_keys
-            Set['targets']
+            Set['command', 'targets']
           end
 
-          def initialize(step_body)
-            super
-            @command = step_body['command']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts = format_options(body)
+
+            args = [body['command'], body['targets']]
+            args << body['description'] if body['description']
+            args << opts if opts.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_command'
-            args = [@command, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'run_command'
           end
         end
       end

--- a/lib/bolt/pal/yaml_plan/step/download.rb
+++ b/lib/bolt/pal/yaml_plan/step/download.rb
@@ -5,31 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Download < Step
-          def self.allowed_keys
-            super + Set['download', 'destination']
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
             Set['download', 'destination', 'targets']
           end
 
-          def initialize(step_body)
-            super
-            @source = step_body['download']
-            @destination = step_body['destination']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts = format_options(body)
+
+            args = [body['download'], body['destination'], body['targets']]
+            args << body['description'] if body['description']
+            args << opts if opts.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'download_file'
-            args = [@source, @destination, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'download_file'
           end
         end
       end

--- a/lib/bolt/pal/yaml_plan/step/eval.rb
+++ b/lib/bolt/pal/yaml_plan/step/eval.rb
@@ -22,7 +22,7 @@ module Bolt
             code = String.new("  ")
             code << "$#{body['name']} = " if body['name']
 
-            code_body = Bolt::Util.to_code(body['eval'])
+            code_body = Bolt::Util.to_code(body['eval']) || 'undef'
 
             # If we're trying to assign the result of a multi-line eval to a name
             # variable, we need to wrap it in `with()`.

--- a/lib/bolt/pal/yaml_plan/step/eval.rb
+++ b/lib/bolt/pal/yaml_plan/step/eval.rb
@@ -5,28 +5,28 @@ module Bolt
     class YamlPlan
       class Step
         class Eval < Step
-          def self.allowed_keys
-            super + Set['eval']
-          end
-
           def self.required_keys
-            Set.new
+            Set['eval']
           end
 
-          def initialize(step_body)
-            super
-            @eval = step_body['eval']
+          # Evaluates the step
+          #
+          def evaluate(scope, evaluator)
+            evaluated = evaluator.evaluate_code_blocks(scope, body)
+            evaluated['eval']
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
+            code << "$#{body['name']} = " if body['name']
 
-            code_body = Bolt::Util.to_code(@eval)
+            code_body = Bolt::Util.to_code(body['eval'])
 
             # If we're trying to assign the result of a multi-line eval to a name
             # variable, we need to wrap it in `with()`.
-            if @name && code_body.lines.count > 1
+            if body['name'] && code_body.lines.count > 1
               indented = code_body.gsub(/\n/, "\n    ").chomp("  ")
               code << "with() || {\n    #{indented}}"
             else

--- a/lib/bolt/pal/yaml_plan/step/message.rb
+++ b/lib/bolt/pal/yaml_plan/step/message.rb
@@ -13,14 +13,23 @@ module Bolt
             Set['message']
           end
 
-          def initialize(step_body)
-            super
-            @message = step_body['message']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            [body['message']]
           end
 
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'out::message'
+          end
+
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << function_call('out::message', [@message])
+            code << function_call(function, format_args(body))
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/plan.rb
+++ b/lib/bolt/pal/yaml_plan/step/plan.rb
@@ -6,30 +6,34 @@ module Bolt
       class Step
         class Plan < Step
           def self.allowed_keys
-            super + Set['plan', 'parameters']
+            super + Set['parameters']
+          end
+
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
-            Set.new
+            Set['plan']
           end
 
-          def initialize(step_body)
-            super
-            @plan = step_body['plan']
-            @parameters = step_body.fetch('parameters', {})
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts   = format_options(body)
+            params = (body['parameters'] || {}).merge(opts)
+
+            args = [body['plan']]
+            args << body['targets'] if body['targets']
+            args << params if params.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_plan'
-            args = [@plan]
-            args << @parameters unless @parameters.empty?
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'run_plan'
           end
         end
       end

--- a/lib/bolt/pal/yaml_plan/step/resources.rb
+++ b/lib/bolt/pal/yaml_plan/step/resources.rb
@@ -5,18 +5,65 @@ module Bolt
     class YamlPlan
       class Step
         class Resources < Step
-          def self.allowed_keys
-            super + Set['resources']
-          end
-
           def self.required_keys
-            Set['targets']
+            Set['resources', 'targets']
           end
 
-          def initialize(step_body)
+          def initialize(body)
             super
-            @resources = step_body['resources']
-            @normalized_resources = normalize_resources(@resources)
+            @body['resources'] = normalize_resources(@body['resources'])
+          end
+
+          def evaluate(scope, evaluator)
+            evaluated = evaluator.evaluate_code_blocks(scope, body)
+
+            scope.call_function('apply_prep', evaluated['targets'])
+
+            manifest = generate_manifest(evaluated['resources'])
+            apply_manifest(scope, evaluated['targets'], manifest)
+          end
+
+          # Generates a manifest from the resources
+          #
+          private def generate_manifest(resources)
+            # inspect returns the Ruby representation of the resource hashes,
+            # which happens to be the same as the Puppet representation
+            puppet_resources = resources.inspect
+
+            # Because the :tasks setting globally controls which mode the parser
+            # is in, we need to make this snippet of non-tasks manifest code
+            # parseable in tasks mode. The way to do that is by putting it in an
+            # apply statement and taking the body.
+            <<~MANIFEST
+            apply('placeholder') {
+              $resources = #{puppet_resources}
+              $resources.each |$res| {
+                Resource[$res['type']] { $res['title']:
+                  * => $res['parameters'],
+                }
+              }
+  
+              # Add relationships if there is more than one resource
+              if $resources.length > 1 {
+                ($resources.length - 1).each |$index| {
+                  $lhs = $resources[$index]
+                  $rhs = $resources[$index+1]
+                  $lhs_resource = Resource[$lhs['type'] , $lhs['title']]
+                  $rhs_resource = Resource[$rhs['type'] , $rhs['title']]
+                  $lhs_resource -> $rhs_resource
+                }
+              }
+            }
+            MANIFEST
+          end
+
+          # Applies the manifest block on the targets
+          #
+          private def apply_manifest(scope, targets, manifest)
+            ast = self.class.parse_code_string(manifest)
+            apply_block = ast.body.body
+            applicator = Puppet.lookup(:apply_executor)
+            applicator.apply([targets], apply_block, scope)
           end
 
           def self.validate(body, step_number)
@@ -26,26 +73,28 @@ module Bolt
               if resource['type'] || resource['title']
                 if !resource['type']
                   err = "Resource declaration must include type key if title key is set"
-                  raise step_error(err, body['name'], step_number)
+                  raise StepError.new(err, body['name'], step_number)
                 elsif !resource['title']
                   err = "Resource declaration must include title key if type key is set"
-                  raise step_error(err, body['name'], step_number)
+                  raise StepError.new(err, body['name'], step_number)
                 end
               else
                 type_keys = (resource.keys - ['parameters'])
                 if type_keys.empty?
                   err = "Resource declaration is missing a type"
-                  raise step_error(err, body['name'], step_number)
+                  raise StepError.new(err, body['name'], step_number)
                 elsif type_keys.length > 1
                   err = "Resource declaration has ambiguous type: could be #{type_keys.join(' or ')}"
-                  raise step_error(err, body['name'], step_number)
+                  raise StepError.new(err, body['name'], step_number)
                 end
               end
             end
           end
 
+          # Normalizes the resources so they are in a format compatible with apply blocks
           # What if this comes from a code block?
-          def normalize_resources(resources)
+          #
+          private def normalize_resources(resources)
             resources.map do |resource|
               if resource['type'] && resource['title']
                 type = resource['type']
@@ -59,25 +108,19 @@ module Bolt
             end
           end
 
-          def body
-            @body.merge('resources' => @normalized_resources)
-          end
-
           def transpile
             code = StringIO.new
 
             code.print "  "
-            fn = 'apply_prep'
-            args = [@targets]
-            code << function_call(fn, args)
+            code << function_call('apply_prep', [@body['targets']])
             code.print "\n"
 
             code.print "  "
-            code.print "$#{@name} = " if @name
+            code.print "$#{@body['name']} = " if @body['name']
 
-            code.puts "apply(#{Bolt::Util.to_code(@targets)}) {"
+            code.puts "apply(#{Bolt::Util.to_code(@body['targets'])}) {"
 
-            declarations = @normalized_resources.map do |resource|
+            declarations = @body['resources'].map do |resource|
               type = resource['type'].is_a?(EvaluableString) ? resource['type'].value : resource['type']
               title = Bolt::Util.to_code(resource['title'])
               parameters = resource['parameters'].transform_values do |val|

--- a/lib/bolt/pal/yaml_plan/step/script.rb
+++ b/lib/bolt/pal/yaml_plan/step/script.rb
@@ -6,35 +6,34 @@ module Bolt
       class Step
         class Script < Step
           def self.allowed_keys
-            super + Set['script', 'parameters', 'arguments']
+            super + Set['arguments']
+          end
+
+          def self.option_keys
+            Set['catch_errors', 'env_vars', 'run_as']
           end
 
           def self.required_keys
-            Set['targets']
+            Set['script', 'targets']
           end
 
-          def initialize(step_body)
-            super
-            @script = step_body['script']
-            @parameters = step_body.fetch('parameters', {})
-            @arguments = step_body.fetch('arguments', [])
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts = format_options(body)
+            opts = opts.merge('arguments' => body['arguments'] || []) if body.key?('arguments')
+
+            args = [body['script'], body['targets']]
+            args << body['description'] if body['description']
+            args << opts if opts.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            options = @parameters.dup
-            options['arguments'] = @arguments unless @arguments.empty?
-
-            fn = 'run_script'
-            args = [@script, @targets]
-            args << @description if @description
-            args << options unless options.empty?
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'run_script'
           end
         end
       end

--- a/lib/bolt/pal/yaml_plan/step/task.rb
+++ b/lib/bolt/pal/yaml_plan/step/task.rb
@@ -6,31 +6,34 @@ module Bolt
       class Step
         class Task < Step
           def self.allowed_keys
-            super + Set['task', 'parameters']
+            super + Set['parameters']
+          end
+
+          def self.option_keys
+            Set['catch_errors', 'noop', 'run_as']
           end
 
           def self.required_keys
-            Set['targets']
+            Set['targets', 'task']
           end
 
-          def initialize(step_body)
-            super
-            @task = step_body['task']
-            @parameters = step_body.fetch('parameters', {})
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts   = format_options(body)
+            params = (body['parameters'] || {}).merge(opts)
+
+            args = [body['task'], body['targets']]
+            args << body['description'] if body['description']
+            args << params if params.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_task'
-            args = [@task, @targets]
-            args << @description if @description
-            args << @parameters unless @parameters.empty?
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'run_task'
           end
         end
       end

--- a/lib/bolt/pal/yaml_plan/step/upload.rb
+++ b/lib/bolt/pal/yaml_plan/step/upload.rb
@@ -5,31 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Upload < Step
-          def self.allowed_keys
-            super + Set['destination', 'upload']
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
-            Set['upload', 'destination', 'targets']
+            Set['destination', 'targets', 'upload']
           end
 
-          def initialize(step_body)
-            super
-            @source = step_body['upload']
-            @destination = step_body['destination']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            opts = format_options(body)
+
+            args = [body['upload'], body['destination'], body['targets']]
+            args << body['description'] if body['description']
+            args << opts if opts.any?
+
+            args
           end
 
-          def transpile
-            code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'upload_file'
-            args = [@source, @destination, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
-            code << "\n"
+          # Returns the function corresponding to the step
+          #
+          private def function
+            'upload_file'
           end
         end
       end

--- a/schemas/bolt-yaml-plan.schema.json
+++ b/schemas/bolt-yaml-plan.schema.json
@@ -77,6 +77,9 @@
       "additionalProperties": false,
       "required": ["command", "targets"],
       "properties": {
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "command": {
           "description": "The command to run.",
           "type": "string"
@@ -84,8 +87,14 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "env_vars": {
+          "$ref": "#/definitions/env_vars"
+        },
         "name": {
           "$ref": "#/definitions/name"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "targets": {
           "$ref": "#/definitions/targets"
@@ -98,6 +107,9 @@
       "additionalProperties": false,
       "required": ["destination", "download", "targets"],
       "properties": {
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
@@ -111,6 +123,9 @@
         },
         "name": {
           "$ref": "#/definitions/name"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "targets": {
           "$ref": "#/definitions/targets"
@@ -140,6 +155,9 @@
       "additionalProperties": false,
       "required": ["plan"],
       "properties": {
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
@@ -153,6 +171,9 @@
         "plan": {
           "description": "The name of the plan to run.",
           "type": "string"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "targets": {
           "$ref": "#/definitions/targets"
@@ -211,11 +232,20 @@
             "type": "string"
           }
         },
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
+        "env_vars": {
+          "$ref": "#/definitions/env_vars"
+        },
         "name": {
           "$ref": "#/definitions/name"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "script": {
           "description": "The script to run. Scripts must be in the files/ directory of a module, and the name of the script must be specified as <modulename>/path/to/script, ommitting the files/ directory from the path.",
@@ -232,15 +262,24 @@
       "additionalProperties": false,
       "required": ["task", "targets"],
       "properties": {
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
         "name": {
           "$ref": "#/definitions/name"
         },
+        "noop": {
+          "$ref": "#/definitions/noop"
+        },
         "parameters": {
           "description": "A map of parameters to pass to the task.",
           "type": "object"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "task": {
           "description": "The task to run.",
@@ -257,6 +296,9 @@
       "additionalProperties": false,
       "required": ["destination", "targets", "upload"],
       "properties": {
+        "catch_errors": {
+          "$ref": "#/definitions/catch_errors"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
@@ -266,6 +308,9 @@
         },
         "name": {
           "$ref": "#/definitions/name"
+        },
+        "run_as": {
+          "$ref": "#/definitions/run_as"
         },
         "targets": {
           "$ref": "#/definitions/targets"
@@ -278,12 +323,28 @@
     }
   },
   "definitions": {
+    "catch_errors": {
+      "description": "Wehther to catch raised errors. If set to true, the plan continues execution if the step fails.",
+      "type": "boolean"
+    },
     "description": {
       "description": "A description of the step. Used by Bolt to describe which step is being executed in plan output.",
       "type": "string"
     },
+    "env_vars": {
+      "description": "A map of environment variables to set on the target when running the step.",
+      "type": "object"
+    },
     "name": {
       "description": "A unique name that can be used to refer to the result of the step later in the plan.",
+      "type": "string"
+    },
+    "noop": {
+      "description": "Whether to run the step in no-operation mode, if available.",
+      "type": "boolean"
+    },
+    "run_as": {
+      "description": "The user to run as on the target with privilege escalation. Only applies to targets using a transport that supports the 'run-as' configuration option.",
       "type": "string"
     },
     "targets": {

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -414,7 +414,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
 
       allow(step).to receive(:apply_manifest)
       expect(step).to receive(:generate_manifest).with(expected).and_return('mymanifest')
-      expect(step).to receive(:apply_manifest).with(scope, target, 'mymanifest')
+      expect(step).to receive(:apply_manifest).with(scope, [target], 'mymanifest')
 
       step.evaluate(scope, subject)
     end


### PR DESCRIPTION
This adds keys to most YAML plan steps that correspond to plan function
metaparameters. For example, the script step now accepts an `env_vars`
key that corresponds to the `_env_vars` metaparameter, and allows users
to set environment variables on a target when executing the script.

This also fixes a bug where targets listed under the `targets` key in a
plan step were not being passed to the plan. Targets specified in this
manner are now passed to the plan correctly.

Lastly, this includes a refactoring of the `Bolt::PAL::YamlPlan::Step`
classes and the `Bolt::PAL::YamlPlan::Evaluator` class. The step classes
now include methods for formatting options and arguments for plan
function calls as well as an `#evaluate` method that handles evaluating
the step body and calling the step's plan function. The evaluator now
calls out to each step's `#evaluate` function to evaluate the step
instead of including separate logic for evaluating each step and
formatting the plan function call. The motivation for this refactoring
was to keep all of the logic for a given step in the step class, as
opposed to spreading it across multiple classes with duplicate logic.

!feature

* **Support metaparameters as top-level keys in YAML plan steps**
  ([#2629](https://github.com/puppetlabs/bolt/issues/2629))

  YAML plan steps now support metaparameters as top-level keys. For
  example, the `script` step supports an `env_vars` key which accepts a
  hash of environment variables to set on the target when running the
  script.

!bug

* **Run YAML plan `plan` steps with `targets` key**

  YAML plans that have a `plan` step with a top-level `targets` key now
  pass the targets to the plan.