### PR TITLE
(GH-2679) Support run-as configuration when downloading files

### DIFF
--- a/lib/bolt/shell/bash/tmpdir.rb
+++ b/lib/bolt/shell/bash/tmpdir.rb
@@ -24,8 +24,8 @@ module Bolt
           end
         end
 
-        def chown(owner)
-          return if owner.nil? || owner == @owner
+        def chown(owner, force: false)
+          return if owner.nil? || (owner == @owner && !force)
 
           result = @shell.execute(['id', '-g', owner])
           if result.exit_code != 0


### PR DESCRIPTION
This updates the SSH transport to respect `run-as` configuration when
downloading files. Specifically, when using `run-as`, Bolt executes the
following steps:

- Create a temporary directory as the run-as user
- Copy the source file to the temporary directory as the run-as user
- Chown the temporary directory and its contents to the connecting user
- Download the copy of the source file as the connecting user
- Delete the temporary directory and contents

This is a workaround to a limitation in the net-ssh library, which only
allows for downloading files as the connecting user. Because Bolt users
might not be able to connect as the root user, the source file needs to
be made available to the connecting user.

Because the temporary directory / file copy are just implementations of
this workaround, the temporary directory is _always_ deleted after
downloading the file, regardless of the user's `cleanup` configuration.

!bug

* **Support `run-as` configuration when downloading files**
  ([#2679](https://github.com/puppetlabs/bolt/issues/2679))

  The `run-as` configuration for the SSH transport is now supported when
  downloading files.