### PR TITLE
(GH-2499) Add 'lookup' command

### DIFF
--- a/documentation/hiera.md
+++ b/documentation/hiera.md
@@ -45,11 +45,79 @@ data set by a user overrides the default data set by the module’s author.
 
 ## Look up data from the command line
 
-If you have used Puppet, you might be familiar with the [`puppet lookup`
-command](https://puppet.com/docs/puppet/latest/hiera_automatic.html#using_puppet_lookup),
-which is the command line interface for the `lookup()` function. Bolt does not
-have an equivalent command line interface, so it is not possible to look up data
-with Hiera outside of running your code in Bolt.
+You can use the `bolt lookup` command and `Invoke-BoltLookup` PowerShell cmdlet
+to look up data from the command line. The `lookup` command looks up data in the
+context of a target, allowing you to interpolate target facts and variables in
+your hierarchy.
+
+> **Note:** The `bolt lookup` and `Invoke-BoltLookup` commands only look up data
+> using the `hierarchy` key in the Hiera configuration file. `plan_hierarchy`
+> is not supported from the command line.
+
+When you run the `bolt lookup` and `Invoke-BoltLookup` commands, Bolt first
+runs an `apply_prep` on each of the targets specified. This installs the
+`puppet-agent` package on the target, collects facts, and then stores the facts
+on the target to be used in interpolations.
+
+Looking up data from the command line is particularly useful if you need to
+debug a plan that includes calls to the `lookup()` function, or if you need to
+look up target-specific data such as a password for authenticating connections
+to the target.
+
+Given the following Hiera configuration at `<PROJECT DIRECTORY>/hiera.yaml`:
+
+```yaml
+# hiera.yaml
+version: 5
+
+hierarchy:
+  - name: "Per-OS defaults"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "Common data"
+    path: "common.yaml"
+```
+
+And the following data source at `<PROJECT DIRECTORY>/data/os/Windows.yaml`:
+
+```yaml
+# data/os/Windows.yaml
+password: Bolt!
+```
+
+And the following data source at `<PROJECT DIRECTORY>/data/os/Ubuntu.yaml`:
+
+```yaml
+# data/os/Ubuntu.yaml
+password: Puppet!
+```
+
+You can look up the value for the `password` key from the command line using
+facts collected from your targets:
+
+_\*nix shell command_
+
+```shell
+bolt lookup password --targets windows_target,ubuntu_target
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Invoke-BoltLooup -Key 'password' -Targets 'windows_target,ubuntu_target'
+```
+
+Bolt prints the value for the key to the console:
+
+```shell
+Starting: install puppet and gather facts on windows_target, ubuntu_target
+Finished: install puppet and gather facts with 0 failures in 6.7 sec
+Finished on windows_target:
+  Bolt!
+Finished on ubuntu_target:
+  Puppet!
+Successful on 2 targets: windows_target, ubuntu_target
+Ran on 2 targets
+```
 
 ## Look up data in plans
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -66,6 +66,9 @@ module Bolt
       when 'guide'
         { flags: OPTIONS[:global] + %w[format],
           banner: GUIDE_HELP }
+      when 'lookup'
+        { flags: ACTION_OPTS + %w[hiera-config],
+          banner: LOOKUP_HELP }
       when 'module'
         case action
         when 'add'
@@ -175,6 +178,7 @@ module Bolt
           guide             View guides for Bolt concepts and features
           inventory         Show the list of targets an action would run on
           module            Manage Bolt project modules
+          lookup            Look up a value with Hiera
           plan              Convert, create, show, and run Bolt plans
           project           Create and migrate Bolt projects
           script            Upload a local script and run it remotely
@@ -353,6 +357,21 @@ module Bolt
           To filter the targets in the list, use the --targets, --query, or --rerun
           options. To view detailed configuration and data for targets, use the
           --detail option.
+    HELP
+
+    LOOKUP_HELP = <<~HELP
+      NAME
+          lookup
+
+      USAGE
+          bolt lookup <key> {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
+
+      DESCRIPTION
+          Look up a value with Hiera.
+
+      EXAMPLES
+          bolt lookup password --targets servers
     HELP
 
     MODULE_HELP = <<~HELP

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -174,12 +174,16 @@ module Bolt
             @stream.puts(remove_trail(indent(2, result.message)))
           end
 
-          # Use special handling if the result looks like a command or script result
-          if result.generic_value.keys == %w[stdout stderr merged_output exit_code]
+          case result.action
+          when 'command', 'script'
             safe_value = result.safe_value
             @stream.puts(indent(2, safe_value['merged_output'])) unless safe_value['merged_output'].strip.empty?
-          elsif result.generic_value.any?
-            @stream.puts(indent(2, ::JSON.pretty_generate(result.generic_value)))
+          when 'lookup'
+            @stream.puts(indent(2, result['value']))
+          else
+            if result.generic_value.any?
+              @stream.puts(indent(2, ::JSON.pretty_generate(result.generic_value)))
+            end
           end
         end
       end

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -83,6 +83,10 @@ module Bolt
         @stream.puts result.to_json
       end
 
+      def print_result_set(result_set)
+        @stream.puts result_set.to_json
+      end
+
       def print_topics(topics)
         print_table('topics' => topics)
       end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -28,6 +28,11 @@ module Bolt
       %w[file line].zip(position).to_h.compact
     end
 
+    def self.for_lookup(target, key, value)
+      val = { 'value' => value }
+      new(target, value: val, action: 'lookup', object: key)
+    end
+
     def self.for_command(target, value, action, command, position)
       details = create_details(position)
       unless value['exit_code'] == 0

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -34,7 +34,7 @@ Describe "test bolt module" {
 
     it "has the correct number of exported functions" {
       # should count of pwsh functions
-      @($commands).Count | Should -Be 23
+      @($commands).Count | Should -Be 24
     }
   }
 }
@@ -303,6 +303,13 @@ Describe "test all bolt command examples" {
     It "bolt task show canary" {
       $results = Get-BoltTask -name 'canary'
       $results | Should -Be "bolt task show canary"
+    }
+  }
+
+  Context "bolt lookup" {
+    It "bolt lookup key --targets target1,target2" {
+      $results = Invoke-BoltLookup -key 'key' -targets 'target1,target2'
+      $results | Should -Be "bolt lookup key --targets target1,target2"
     }
   }
 }

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -47,6 +47,7 @@ namespace :pwsh do
       'download'   => 'Receive',
       'init'       => 'New',
       'install'    => 'Install',
+      'lookup'     => 'Invoke',
       'migrate'    => 'Update',
       'new'        => 'New',
       'run'        => 'Invoke',
@@ -89,7 +90,7 @@ namespace :pwsh do
         matches = help_text[:banner].match(/USAGE(?<usage>.+?)DESCRIPTION(?<desc>.+?)(EXAMPLES|\z)/m)
         action.chomp unless action.nil?
 
-        if action.nil? && subcommand == 'apply'
+        if action.nil? && %w[apply lookup].include?(subcommand)
           cmdlet_verb = 'Invoke'
           cmdlet_noun = "Bolt#{subcommand.capitalize}"
         elsif @hardcoded_cmdlets["#{subcommand}:#{action}"]
@@ -274,6 +275,20 @@ namespace :pwsh do
               validate_not_null_or_empty: true
             }
           end
+        when 'lookup'
+          # bolt lookup <key> [options]
+          @pwsh_command[:options] << {
+            name:                       'Key',
+            ruby_short:                 'k',
+            parameter_set:              'key',
+            help_msg:                   'The key to look up',
+            type:                       'string',
+            switch:                     false,
+            mandatory:                  true,
+            position:                   0,
+            ruby_arg:                   'bare',
+            validate_not_null_or_empty: true
+          }
         end
 
         # verbose is a commonparameter and is already present in the

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -169,6 +169,42 @@ describe "Bolt::CLI" do
     end
   end
 
+  context 'lookup' do
+    let(:pal)     { double('pal', lookup: results) }
+    let(:results) { Bolt::ResultSet.new([]) }
+
+    around(:each) do |example|
+      in_project do |project|
+        @project = project
+        example.run
+      end
+    end
+
+    it 'errors without a key' do
+      expect { Bolt::CLI.new(%w[lookup]).parse }.to raise_error(
+        Bolt::CLIError,
+        /Must specify a key to look up/
+      )
+    end
+
+    it 'errors without a targeting option' do
+      cli = Bolt::CLI.new(%w[lookup key])
+
+      expect { cli.execute(cli.parse) }.to raise_error(
+        Bolt::CLIError,
+        /Command requires a targeting option/
+      )
+    end
+
+    it 'calls Bolt::PAL#lookup' do
+      allow(Bolt::PAL).to receive(:new).and_return(pal)
+      expect(pal).to receive(:lookup)
+
+      cli = Bolt::CLI.new(%w[lookup key --targets foo])
+      cli.execute(cli.parse)
+    end
+  end
+
   context 'module' do
     let(:cli)            { Bolt::CLI.new(command) }
     let(:command)        { %w[module show] }

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -249,6 +249,12 @@ describe "Bolt::Outputter::Human" do
     expect(lines).to match(/^    "key": "val"$/)
   end
 
+  it 'prints lookup results' do
+    result = Bolt::Result.for_lookup(target, 'key', 'value')
+    outputter.print_result(result)
+    expect(output.string).to match(/value/)
+  end
+
   it "prints empty results from a plan" do
     outputter.print_plan_result(Bolt::PlanResult.new([], 'success'))
     expect(output.string).to eq("[\n\n]\n")

--- a/spec/fixtures/hiera/bolt-project.yaml
+++ b/spec/fixtures/hiera/bolt-project.yaml
@@ -1,0 +1,3 @@
+name: hiera
+log:
+  bolt-debug.log: disable

--- a/spec/fixtures/hiera/data/nodes/puppet_7_node.yaml
+++ b/spec/fixtures/hiera/data/nodes/puppet_7_node.yaml
@@ -1,0 +1,1 @@
+certname: certname data/puppet_7_node.yaml

--- a/spec/fixtures/hiera/data/os/Ubuntu.yaml
+++ b/spec/fixtures/hiera/data/os/Ubuntu.yaml
@@ -1,0 +1,1 @@
+os: os data/os/Ubuntu.yaml

--- a/spec/fixtures/hiera/data/var.yaml
+++ b/spec/fixtures/hiera/data/var.yaml
@@ -1,0 +1,1 @@
+var: var data/var.yaml

--- a/spec/fixtures/hiera/hiera_interpolations.yaml
+++ b/spec/fixtures/hiera/hiera_interpolations.yaml
@@ -5,8 +5,14 @@ defaults:
   data_hash: yaml_data
 
 hierarchy:
-  - name: "Interpolations"
+  - name: "Fact interpolations"
     path: "os/%{facts.os.name}.yaml"
+
+  - name: "Var interpolations"
+    path: "%{lookup}.yaml"
+
+  - name: "Trusted interpolations"
+    path: "nodes/%{trusted.certname}.yaml"
 
   - name: "Common"
     path: "common.yaml"

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -1,163 +1,278 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/env_var'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
 
-describe "lookup() in plans" do
+describe 'lookup' do
+  include BoltSpec::EnvVar
   include BoltSpec::Files
   include BoltSpec::Integration
-
-  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:project)      { fixtures_path('hiera') }
   let(:hiera_config) { File.join(project, 'hiera.yaml') }
   let(:plan)         { 'test::lookup' }
 
-  let(:cli_command) {
-    %W[plan run #{plan} --project #{project} --hiera-config #{hiera_config}]
-  }
-
-  it 'returns a value' do
-    result = run_cli_json(cli_command + %w[key=environment])
-    expect(result).to eq('environment data/common.yaml')
+  after(:each) do
+    Puppet.settings.send(:clear_everything_for_tests)
   end
 
-  it 'accepts a default value' do
-    options = { 'default_value' => 'default' }.to_json
-    result  = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
-    expect(result).to eq('default')
-  end
+  context 'plan function' do
+    let(:cli_command) {
+      %W[plan run #{plan} --project #{project} --hiera-config #{hiera_config}]
+    }
 
-  it 'accepts a default values hash' do
-    options = { 'default_values_hash' => { 'foo::bar::baz' => 'default' } }.to_json
-    result  = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
-    expect(result).to eq('default')
-  end
-
-  it 'searches the module hierarchy' do
-    result = run_cli_json(cli_command + %w[key=test::module])
-    expect(result).to eq('test::module modules/test/data/common.yaml')
-  end
-
-  it 'does not search the module hierarchy in a different namespace' do
-    result = run_cli_json(cli_command + %w[key=foo::namespace])
-    expect(result).to include(
-      'kind' => 'bolt/pal-error',
-      'msg'  => /Function lookup\(\) did not find a value for the name 'foo::namespace'/
-    )
-  end
-
-  it 'does not search for global keys in the module hierarchy' do
-    result = run_cli_json(cli_command + %w[key=global])
-    expect(result).to include(
-      'kind' => 'bolt/pal-error',
-      'msg'  => /Function lookup\(\) did not find a value for the name 'global'/
-    )
-  end
-
-  it 'merges values' do
-    options = { 'merge' => 'deep' }.to_json
-    result  = run_cli_json(cli_command + %W[key=test::merge options=#{options}])
-    expect(result).to match(
-      'bolt'   => { 'key1' => 'value1', 'key2' => 'value1' },
-      'puppet' => { 'key1' => 'value1' }
-    )
-  end
-
-  context 'with a lambda' do
-    let(:plan) { 'test::lookup_lambda' }
-
-    it 'returns a value from the lambda' do
-      result = run_cli_json(cli_command + %w[key=foo::bar::baz])
-      expect(result).to eq('foo bar baz lambda')
+    it 'returns a value' do
+      result = run_cli_json(cli_command + %w[key=environment])
+      expect(result).to eq('environment data/common.yaml')
     end
 
-    it 'returns a value from the lambda over the default value' do
+    it 'accepts a default value' do
       options = { 'default_value' => 'default' }.to_json
-      result = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
-      expect(result).to eq('foo bar baz lambda')
-    end
-
-    it 'returns a value from the default values hash over the lambda' do
-      options = { 'default_values_hash' => { 'foo::bar::baz' => 'default values hash' } }.to_json
       result  = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
-      expect(result).to eq('default values hash')
+      expect(result).to eq('default')
     end
-  end
 
-  context 'with interpolations' do
-    let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
+    it 'accepts a default values hash' do
+      options = { 'default_values_hash' => { 'foo::bar::baz' => 'default' } }.to_json
+      result  = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
+      expect(result).to eq('default')
+    end
 
-    it 'returns an error' do
-      result = run_cli_json(cli_command + %w[key=test::interpolations])
+    it 'searches the module hierarchy' do
+      result = run_cli_json(cli_command + %w[key=test::module])
+      expect(result).to eq('test::module modules/test/data/common.yaml')
+    end
+
+    it 'does not search the module hierarchy in a different namespace' do
+      result = run_cli_json(cli_command + %w[key=foo::namespace])
       expect(result).to include(
         'kind' => 'bolt/pal-error',
-        'msg'  => /Interpolations are not supported in lookups/
+        'msg'  => /Function lookup\(\) did not find a value for the name 'foo::namespace'/
       )
     end
-  end
 
-  context 'with a builtin backend' do
-    # Load pkcs7 keys as environment variables
-    before(:each) do
-      ENV['BOLT_PKCS7_PUBLIC_KEY']  = File.read(File.expand_path('../keys/public_key.pkcs7.pem', project))
-      ENV['BOLT_PKCS7_PRIVATE_KEY'] = File.read(File.expand_path('../keys/private_key.pkcs7.pem', project))
-    end
-
-    after(:each) do
-      ENV.delete('BOLT_PKCS7_PUBLIC_KEY')
-      ENV.delete('BOLT_PKCS7_PRIVATE_KEY')
-    end
-
-    it 'returns a value' do
-      result = run_cli_json(cli_command + %w[key=test::secret])
-      expect(result).to eq('test::secret data/secret.eyaml')
-    end
-  end
-
-  context 'with a custom backend' do
-    it 'returns a value' do
-      result = run_cli_json(cli_command + %w[key=test::custom])
-      expect(result).to eq('test::custom data/custom.txt')
-    end
-  end
-
-  context 'with a missing backend' do
-    let(:hiera_config) { File.join(project, 'hiera_missing_backend.yaml') }
-
-    it 'returns an error' do
-      result = run_cli_json(cli_command + %w[key=test::backends])
+    it 'does not search for global keys in the module hierarchy' do
+      result = run_cli_json(cli_command + %w[key=global])
       expect(result).to include(
         'kind' => 'bolt/pal-error',
-        'msg'  => /Unable to find 'data_hash' function named 'missing_backend'/
+        'msg'  => /Function lookup\(\) did not find a value for the name 'global'/
       )
     end
-  end
 
-  context 'with plan_hiera' do
-    let(:hiera_config) { File.join(project, 'plan_hiera.yaml') }
-    let(:plan)         { 'test::plan_lookup' }
-    let(:uri)          { 'localhost' }
+    it 'merges values' do
+      options = { 'merge' => 'deep' }.to_json
+      result  = run_cli_json(cli_command + %W[key=test::merge options=#{options}])
+      expect(result).to match(
+        'bolt'   => { 'key1' => 'value1', 'key2' => 'value1' },
+        'puppet' => { 'key1' => 'value1' }
+      )
+    end
 
-    it 'uses plan_hierarchy outside apply block, and hierarchy in apply block' do
-      result = run_cli_json(cli_command + %W[-t #{uri}])
-      expect(result['outside_apply']).to eq('goes the weasel')
-      expect(result['in_apply'].keys).to include('Notify[tarts]')
+    context 'with a lambda' do
+      let(:plan) { 'test::lookup_lambda' }
+
+      it 'returns a value from the lambda' do
+        result = run_cli_json(cli_command + %w[key=foo::bar::baz])
+        expect(result).to eq('foo bar baz lambda')
+      end
+
+      it 'returns a value from the lambda over the default value' do
+        options = { 'default_value' => 'default' }.to_json
+        result = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
+        expect(result).to eq('foo bar baz lambda')
+      end
+
+      it 'returns a value from the default values hash over the lambda' do
+        options = { 'default_values_hash' => { 'foo::bar::baz' => 'default values hash' } }.to_json
+        result  = run_cli_json(cli_command + %W[key=foo::bar::baz options=#{options}])
+        expect(result).to eq('default values hash')
+      end
+    end
+
+    context 'with interpolations' do
+      let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
+
+      it 'returns an error' do
+        result = run_cli_json(cli_command + %w[key=test::interpolations])
+        expect(result).to include(
+          'kind' => 'bolt/pal-error',
+          'msg'  => /Interpolations are not supported in lookups/
+        )
+      end
+    end
+
+    context 'with a builtin backend' do
+      # Load pkcs7 keys as environment variables
+      around(:each) do |example|
+        env_vars = {
+          'BOLT_PKCS7_PUBLIC_KEY'  => File.read(File.expand_path('../keys/public_key.pkcs7.pem', project)),
+          'BOLT_PKCS7_PRIVATE_KEY' => File.read(File.expand_path('../keys/private_key.pkcs7.pem', project))
+        }
+
+        with_env_vars(env_vars) do
+          example.run
+        end
+      end
+
+      it 'returns a value' do
+        result = run_cli_json(cli_command + %w[key=test::secret])
+        expect(result).to eq('test::secret data/secret.eyaml')
+      end
+    end
+
+    context 'with a custom backend' do
+      it 'returns a value' do
+        result = run_cli_json(cli_command + %w[key=test::custom])
+        expect(result).to eq('test::custom data/custom.txt')
+      end
+    end
+
+    context 'with a missing backend' do
+      let(:hiera_config) { File.join(project, 'hiera_missing_backend.yaml') }
+
+      it 'returns an error' do
+        result = run_cli_json(cli_command + %w[key=test::backends])
+        expect(result).to include(
+          'kind' => 'bolt/pal-error',
+          'msg'  => /Unable to find 'data_hash' function named 'missing_backend'/
+        )
+      end
+    end
+
+    context 'with plan_hiera' do
+      let(:hiera_config) { File.join(project, 'plan_hiera.yaml') }
+      let(:plan)         { 'test::plan_lookup' }
+      let(:uri)          { 'localhost' }
+
+      it 'uses plan_hierarchy outside apply block, and hierarchy in apply block' do
+        result = run_cli_json(cli_command + %W[-t #{uri}])
+        expect(result['outside_apply']).to eq('goes the weasel')
+        expect(result['in_apply'].keys).to include('Notify[tarts]')
+      end
+    end
+
+    context 'with invalid plan_hierarchy' do
+      let(:hiera_config) { File.join(project, 'plan_hiera_interpolations.yaml') }
+      let(:plan)         { 'test::plan_lookup' }
+      let(:uri)          { 'localhost' }
+
+      it 'raises a validation error' do
+        result = run_cli_json(cli_command + %W[-t #{uri}])
+        expect(result).to include(
+          'kind' => 'bolt/pal-error',
+          'msg'  => /Interpolations are not supported in lookups/
+        )
+      end
     end
   end
 
-  context 'with invalid plan_hierarchy' do
-    let(:hiera_config) { File.join(project, 'plan_hiera_interpolations.yaml') }
-    let(:plan)         { 'test::plan_lookup' }
-    let(:uri)          { 'localhost' }
+  context 'command', ssh: true do
+    include BoltSpec::Conn
 
-    it 'raises a validation error' do
-      result = run_cli_json(cli_command + %W[-t #{uri}])
+    let(:opts)   { %W[--project #{project} --hiera-config #{hiera_config} -t #{target}] }
+    let(:target) { 'puppet_7_node' }
+
+    around(:each) do |example|
+      inventory = docker_inventory.merge('vars' => { 'lookup' => 'var' }).to_json
+
+      env_vars = {
+        'BOLT_INVENTORY'         => inventory,
+        'BOLT_PKCS7_PUBLIC_KEY'  => File.read(File.expand_path('../keys/public_key.pkcs7.pem', project)),
+        'BOLT_PKCS7_PRIVATE_KEY' => File.read(File.expand_path('../keys/private_key.pkcs7.pem', project))
+      }
+
+      with_env_vars(env_vars) do
+        example.run
+      end
+    end
+
+    it 'looks up a value' do
+      result, = run_cli_json(%w[lookup environment] + opts)
       expect(result).to include(
-        'kind' => 'bolt/pal-error',
-        'msg'  => /Interpolations are not supported in lookups/
+        'object' => 'environment',
+        'value'  => { 'value' => 'environment data/common.yaml' }
       )
+    end
+
+    context 'with interpolations' do
+      let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
+
+      it 'looks up a value with facts' do
+        result, = run_cli_json(%w[lookup os] + opts)
+        expect(result).to include(
+          'object' => 'os',
+          'value'  => { 'value' => 'os data/os/Ubuntu.yaml' }
+        )
+      end
+
+      it 'looks up a value with vars' do
+        result, = run_cli_json(%w[lookup var] + opts)
+        expect(result).to include(
+          'object' => 'var',
+          'value'  => { 'value' => 'var data/var.yaml' }
+        )
+      end
+
+      it 'looks up a value with a trusted fact' do
+        result, = run_cli_json(%w[lookup certname] + opts)
+        expect(result).to include(
+          'object' => 'certname',
+          'value'  => { 'value' => 'certname data/puppet_7_node.yaml' }
+        )
+      end
+    end
+
+    it 'looks up a value in the module hierarchy' do
+      result, = run_cli_json(%w[lookup test::module] + opts)
+      expect(result).to include(
+        'object' => 'test::module',
+        'value'  => { 'value' => 'test::module modules/test/data/common.yaml' }
+      )
+    end
+
+    it 'errors with a missing key' do
+      result, = run_cli_json(%w[lookup fizzbuzz] + opts)
+
+      expect(result.dig('value', '_error', 'msg')).to eq(
+        "Function lookup() did not find a value for the name 'fizzbuzz'"
+      )
+    end
+
+    it 'looks up a value with a built-in backend' do
+      result, = run_cli_json(%w[lookup test::secret] + opts)
+      expect(result).to include(
+        'object' => 'test::secret',
+        'value'  => { 'value' => 'test::secret data/secret.eyaml' }
+      )
+    end
+
+    it 'looks up a value with a custom backend' do
+      result, = run_cli_json(%w[lookup test::custom] + opts)
+      expect(result).to include(
+        'object' => 'test::custom',
+        'value'  => { 'value' => 'test::custom data/custom.txt' }
+      )
+    end
+
+    context 'with a missing backend' do
+      let(:hiera_config) { File.join(project, 'hiera_missing_backend.yaml') }
+
+      it 'returns an error' do
+        result, = run_cli_json(%w[lookup test::backends] + opts)
+        expect(result.dig('value', '_error', 'msg')).to match(
+          /Unable to find 'data_hash' function named 'missing_backend'/
+        )
+      end
+    end
+
+    it 'looks up the same value as a plan lookup' do
+      plan_result     = run_cli_json(%W[plan run #{plan} key=environment] + opts)
+      command_result, = run_cli_json(%w[lookup environment] + opts)
+
+      expect(command_result.dig('value', 'value')).to eq(plan_result)
     end
   end
 end


### PR DESCRIPTION
This adds a new `lookup` command to Bolt that looks up values with
Hiera. The command first runs `apply_prep` on each target to install the
puppet-agent package and collect facts, then sets up Hiera and looks for
the specified key in the hierarchy. The command requires a targeting
option, and the Hiera lookup is performed in the context of each target
passed to the command, allowing for interpolations using facts.

!feature

* **`lookup` command to look up values with Hiera**
  ([#2499](https://github.com/puppetlabs/bolt/issues/2499))

  The new `bolt lookup` and `Invoke-BoltLookup` commands can be used to
  look up values with Hiera.