### PR TITLE
(GH-2900) Don't print messages twice

### DIFF
--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -5,7 +5,9 @@ require 'bolt/util/format'
 # Output a message for the user.
 #
 # This will print a message to stdout when using the human output format,
-# and print to stderr when using the json output format
+# and print to stderr when using the json output format. Messages are
+# also logged at the `info` level. For more information about logs, see
+# [Logs](logs.md).
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:'out::message') do
@@ -26,7 +28,7 @@ Puppet::Functions.create_function(:'out::message') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :message, message: Bolt::Util::Format.stringify(message))
+      executor.publish_event(type: :message, message: Bolt::Util::Format.stringify(message), level: :info)
     end
 
     nil

--- a/bolt-modules/out/lib/puppet/functions/out/verbose.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/verbose.rb
@@ -5,7 +5,9 @@ require 'bolt/util/format'
 # Output a message for the user when running in verbose mode.
 #
 # This will print a message to stdout when using the human output format,
-# and print to stderr when using the json output format.
+# and print to stderr when using the json output format. Messages are
+# also logged at the `debug` level. For more information about logs, see
+# [Logs](logs.md).
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:'out::verbose') do
@@ -25,7 +27,7 @@ Puppet::Functions.create_function(:'out::verbose') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :verbose, message: Bolt::Util::Format.stringify(message))
+      executor.publish_event(type: :verbose, message: Bolt::Util::Format.stringify(message), level: :debug)
     end
 
     nil

--- a/bolt-modules/out/spec/functions/out/message_spec.rb
+++ b/bolt-modules/out/spec/functions/out/message_spec.rb
@@ -14,10 +14,11 @@ describe 'out::message' do
     end
   end
 
-  it 'sends a log event to the executor' do
+  it 'sends a message event to the executor' do
     executor.expects(:publish_event).with(
       type:    :message,
-      message: 'This is a message'
+      message: 'This is a message',
+      level:   :info
     )
 
     is_expected.to run.with_params('This is a message')

--- a/bolt-modules/out/spec/functions/out/verbose_spec.rb
+++ b/bolt-modules/out/spec/functions/out/verbose_spec.rb
@@ -17,7 +17,8 @@ describe 'out::verbose' do
   it 'sends a verbose event to the executor' do
     executor.expects(:publish_event).with(
       type:    :verbose,
-      message: 'This is a message'
+      message: 'This is a message',
+      level:   :debug
     )
 
     is_expected.to run.with_params('This is a message')

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -264,21 +264,24 @@ plan mymodule::myplan {
 By default, Bolt does not print verbose logs for each plan execution to stdout.
 However, you can use one of the following methods to investigate a plan
 execution:
+
 - Each time you run a Bolt command, Bolt prints a debug log to a
   `bolt-debug.log` file in the root of your project directory.
 - You can use the `--verbose` CLI option for verbose logging to stdout.
-- You can print a message to stdout using the `out::message` function. 
+- You can print a message to stdout and the `info` log level using the
+  `out::message` function. 
 - You can adjust your log level for detailed information on how Bolt is
   executing your plan.
 
 ### Using `out::message` to debug a plan
 
-You can print a message, or a variable, to stdout using the `out::message`
-function. If the variable contains a valid plan result, Bolt formats the plan
-result using a JSON representation of the result object. If the object is not a
-plan result, Bolt prints the object as a string.
+You can print a message, or a variable, to stdout and to the `info` log level
+using the `out::message` function. If the variable contains a valid plan result,
+Bolt formats the plan result using a JSON representation of the result object.
+If the object is not a plan result, Bolt prints the object as a string.
 
-To print a variable to stdout with `out::message`, use the following syntax:
+To print a variable to stdout and the `info` log level with `out::message`, use
+the following syntax:
 
 ```puppet
 out::message($variable) 
@@ -849,9 +852,9 @@ plan pdb_discover {
 
 ## Plan logging
 
-Print message strings to `STDOUT` using the plan function `out::message`. This
-function always prints messages regardless of the log level and doesn't log them
-to the log file.
+Print message strings to stdout using the `out::message` plan function. This
+function prints messages at the `info` level and always prints messages to
+stdout regardless of the log level.
 
 ### Default action logging
 

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -147,6 +147,18 @@ module Bolt
       Logging.reset
     end
 
+    # Checks if the specified level logs to the console.
+    #
+    def self.log_to_console?(level)
+      configured? && console_level <= Logging.level_num(level)
+    end
+
+    # Returns the log level for the console.
+    #
+    def self.console_level
+      Logging.logger[:root].appenders.select { |appender| appender.name == 'console' }.first&.level
+    end
+
     # The following methods are used in place of the Logging.logger
     # methods of the same name when logging warning messages or logging
     # any messages prior to the logger being configured. If the logger

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -24,7 +24,7 @@ module Bolt
           log_container_start(event)
         when :container_finish
           log_container_finish(event)
-        when :log
+        when :log, :message, :verbose
           log_message(**event)
         end
       end

--- a/spec/fixtures/modules/output/plans/verbose.pp
+++ b/spec/fixtures/modules/output/plans/verbose.pp
@@ -1,3 +1,3 @@
-plan output::verbose(){
+plan output::verbose() {
   out::verbose("Hi, I'm Dave")
 }

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -77,25 +77,37 @@ describe 'plans' do
 
       let(:config_flags) { ['--no-host-key-check'] }
       let(:opts)         { { outputter: Bolt::Outputter::Human, project: @project } }
+      let(:project)      { @project }
 
       context 'output' do
-        let(:output)    { StringIO.new }
-        let(:outputter) { Bolt::Outputter::Human.new(true, true, true, true, output) }
+        context 'out::message' do
+          it 'outputs messages' do
+            result = run_cli(%w[plan run output], outputter: Bolt::Outputter::Human, project: project)
+            expect(result).to match(/Outputting a message/)
+          end
 
-        before(:each) do
-          allow(Bolt::Outputter::Human).to receive(:new).and_return(outputter)
+          it 'logs messages at the info level' do
+            run_cli(%w[plan run output], outputter: Bolt::Outputter::Human, project: project)
+            expect(@log_output.readlines).to include(/INFO.*Outputting a message/)
+          end
         end
 
-        it 'outputs message with verbose flag' do
-          run_cli(%W[plan run output::verbose --targets #{target} --verbose] + config_flags,
-                  outputter: Bolt::Outputter::Human, project: @project)
-          expect(output.string).to match(/Hi, I'm Dave/)
-        end
+        context 'out::verbose' do
+          it 'outputs verbose messages in verbose mode' do
+            result = run_cli(%w[plan run output::verbose --verbose], outputter: Bolt::Outputter::Human,
+                                                                     project: project)
+            expect(result).to match(/Hi, I'm Dave/)
+          end
 
-        it 'doesnt output without verbose flag' do
-          result = run_cli(%W[plan run output::verbose --targets #{target}] + config_flags,
-                           outputter: Bolt::Outputter::Human, project: @project)
-          expect(result).not_to match(/Hi, I'm Dave/)
+          it 'does not output verbose messages' do
+            result = run_cli(%w[plan run output::verbose], outputter: Bolt::Outputter::Human, project: project)
+            expect(result).not_to match(/Hi, I'm Dave/)
+          end
+
+          it 'logs verbose messages at the debug level' do
+            run_cli(%w[plan run output::verbose], outputter: Bolt::Outputter::Human, project: project)
+            expect(@log_output.readlines).to include(/DEBUG.*Hi, I'm Dave/)
+          end
         end
       end
 

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -17,8 +17,9 @@ module BoltSpec
       allow(cli).to receive(:puppetdb_client).and_return(pdb_client)
       allow(cli).to receive(:analytics).and_return(Bolt::Analytics::NoopClient.new)
 
+      verbose = arguments.include?('--verbose')
       output =  StringIO.new
-      outputter = outputter.new(false, false, false, false, output)
+      outputter = outputter.new(false, verbose, false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)
 
       # Don't allow tests to override the captured log config


### PR DESCRIPTION
This adds new functions to the Bolt Logger library to determine the most
verbose (or lowest) log level that will be logged to the console, and
avoid double-printing messages from the `out` module if they will
already be printed by the Logger outputter.